### PR TITLE
Fix check arm-none-eabi-ar tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Coders, editors for documents, testers who can use CLI are needed! Please join u
 
 [korgano] (https://github.com/korgano)
 
+[bigboss] (https://github.com/psxdev)
+
 Please add yourself to this list when you make changes on your fork and submit a pull request.
 
 ## Usage

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -32,6 +32,7 @@ if test "$ac_compiler_gnu" = yes; then
 	CFLAGS="$CFLAGS -Wall -mcpu=cortex-a9 -mfpu=neon-fp16"
 fi
 
+AC_CHECK_TOOL(AR, ar, :) 
 AM_PROG_AS
 
 # Checks for header files.


### PR DESCRIPTION
In osx without this fix when i do objdump from a lib i got:

arm-none-eabi-objdump -D libc_stub.a
In archive libc_stub.a:

_SceLibc-0001_head.o:     file format elf32-littlearm


Disassembly of section .sce_libgen_mark:

00000000 <_SceLibc_0001_stub_head>:
   0:	00000018 	andeq	r0, r0, r8, lsl r0
	...
   c:	00000001 	andeq	r0, r0, r1
	...

00000018 <_sce_package_version_SceLibc>:
  18:	00000000 	andeq	r0, r0, r0

Disassembly of section .sceImport.rodata:

00000000 <_SceLibc_stub_str>:
   0:	4c656353 	stclmi	3, cr6, [r5], #-332	; 0xfffffeb4
   4:	00636269 	rsbeq	r6, r3, r9, ror #4

Disassembly of section .ARM.attributes:

00000000 <.ARM.attributes>:
   0:	00002c41 	andeq	r2, r0, r1, asr #24
   4:	61656100 	cmnvs	r5, r0, lsl #2
   8:	01006962 	tsteq	r0, r2, ror #18
   c:	00000022 	andeq	r0, r0, r2, lsr #32
  10:	726f4305 	rsbvc	r4, pc, #335544320	; 0x14000000
  14:	2d786574 	cfldr64cs	mvdx6, [r8, #-464]!	; 0xfffffe30
  18:	06003941 	streq	r3, [r0], -r1, asr #18
  1c:	0841070a 	stmdaeq	r1, {r1, r3, r8, r9, sl}^
  20:	0a020901 	beq	8242c <_sce_package_version_SceLibc+0x82414>
  24:	24010c03 	strcs	r0, [r1], #-3075	; 0xfffff3fd
  28:	44012a01 	strmi	r2, [r1], #-2561	; 0xfffff5ff
  2c:	Address 0x000000000000002c is out of bounds.

arm-none-eabi-objdump: libc_stub.a: Malformed archive

after the check all is fine. AR is arm-none-eabi-ar