### PR TITLE
Add gxt.h header draft for texture loading

### DIFF
--- a/src/include/psp2/gxm.h
+++ b/src/include/psp2/gxm.h
@@ -353,6 +353,10 @@ typedef enum SceGxmMultisampleMode {
 	SCE_GXM_MULTISAMPLE_4X
 } SceGxmMultisampleMode;
 
+typedef enum SceGxmTextureAlignmentMode {
+    SCE_GXM_TEXTURE_ALIGNMENT
+} SceGxmTextureAlignmentMode;
+
 typedef enum SceGxmTextureSwizzle4Mode {
 	SCE_GXM_TEXTURE_SWIZZLE4_ABGR	= 0x00000000u,
 	SCE_GXM_TEXTURE_SWIZZLE4_ARGB	= 0x00001000u,

--- a/src/include/psp2/gxt.h
+++ b/src/include/psp2/gxt.h
@@ -1,0 +1,21 @@
+/**
+ * \file
+ * \brief Header file which defines GXT variables and functions
+ *
+ * Copyright (C) 2015 PSP2SDK Project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef _PSP2_GXT_
+#define _PSP2_GXT_
+
+#include "gxm.h"
+
+int sceGxtInitTexture(const SceGxmTexture *texture, const ScePVoid data, SceUInt8* data, int flag);
+const ScePVoid sceGxtGetDataAddress(const ScePVoid data);
+const SceSize sceGxtGetDataSize(const ScePVoid data);
+
+#endif


### PR DESCRIPTION
These were discovered while searching for Gxm docs on the internet. google "sceGxtInitTexture" for more info. The signature is not 100% correct for sure and I don't have any value for the added enum, and I didn't add any code to look for these symbols